### PR TITLE
feat: added some docs and made yeet check for a bypass role.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
+# IDEs
+.vs
+.idea
+
+# Build stuff
 build
+cmake-build-debug
+
+# Config stuff
 config.json

--- a/README.md
+++ b/README.md
@@ -4,17 +4,20 @@ This is a bot powered by the [D++ library](https://dpp.dev) which runs images on
 
 ![image](https://github.com/brainboxdotcc/yeet/assets/1556794/1366d2c3-9c4f-46ac-82d0-ad698d994487) ![image](https://github.com/brainboxdotcc/yeet/assets/1556794/8b4b0173-db2e-4489-a50f-a4582c7de228)
 
-
 ## Compilation
 
-    mkdir build
-    cd build
-    cmake ..
-    make -j
+```bash
+mkdir build
+cd build
+cmake ..
+make -j
+```
 
 If DPP is installed in a different location you can specify the root directory to look in while running cmake 
 
-    cmake .. -DDPP_ROOT_DIR=<your-path>
+```bash
+cmake .. -DDPP_ROOT_DIR=<your-path>
+```
 
 ## Running the template bot
 
@@ -25,6 +28,10 @@ Create a config.json in the directory above the build directory:
     "token": "your bot token here", 
     "homeserver": "server id of server where the bot should run",
     "logchannel": "server id where logs go",
+    "bypassroles": [
+        "roles that will bypass checks",
+        "..."
+    ],
     "patterns": [
         "wildcard patterns",
         "..."
@@ -36,6 +43,7 @@ Create a config.json in the directory above the build directory:
 
 * Imagemagick command line tools
 * Tesseract v5.x
+* fmt
 * wget
 * g++ 8.0 or later
 * cmake
@@ -43,6 +51,7 @@ Create a config.json in the directory above the build directory:
 
 Start the bot:
 
-    cd build
-    ./yeet
-
+```bash
+cd build
+./yeet
+```

--- a/config-example.json
+++ b/config-example.json
@@ -2,6 +2,7 @@
 	"token": "token goes here", 
 	"homeserver": "825407338755653642",
 	"logchannel": "1162147665753153707",
+	"bypassrole": "1006130853988016188",
 	"patterns": [
 		"yeet",
 		"yeet*YEET",

--- a/config-example.json
+++ b/config-example.json
@@ -2,7 +2,10 @@
 	"token": "token goes here", 
 	"homeserver": "825407338755653642",
 	"logchannel": "1162147665753153707",
-	"bypassrole": "1006130853988016188",
+	"bypassroles": [
+		"1006130853988016188",
+		"825412797630382121"
+	],
 	"patterns": [
 		"yeet",
 		"yeet*YEET",


### PR DESCRIPTION
> I'm not gonna accept PRs to yeet atm - Brain 2023

I have done it anyways 🔥

This PR adds documentation to the functions, because i'm seriously addicted to documenting functions. It also adds a check for a bypass role, defined by the config. This means people can specify a role that will bypass the checker. The checking required inserting everything into a lambda inside `guild_get_member` due to no coro.