### PR TITLE
feat: allowed roles to be set by command

### DIFF
--- a/include/yeet/database.h
+++ b/include/yeet/database.h
@@ -46,7 +46,7 @@ namespace db {
 	/* Disconnect from database */
 	bool close();
 	/* Issue a database query and return results */
-	resultset query(const std::string &format, const paramlist &parameters);
+	resultset query(const std::string &format, const paramlist &parameters = {});
 	/* Returns the last error string */
 	const std::string& error();
 };


### PR DESCRIPTION
This PR adds a command to allow bypass roles to be set for each guild. It uses a select menu.